### PR TITLE
Implement ConfigDB notify interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+docs
 node_modules

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,9 @@ base=	ghcr.io/amrc-factoryplus/acs-base-js-build:v3.0.0
 
 all:
 
-.PHONY: all dev
+.PHONY: all
+
+.PHONY: check-committed lint docs amend dev pubdev
 
 check-committed:
 	[ -z "$$(git status --porcelain)" ] || (git status; exit 1)
@@ -14,9 +16,9 @@ check-committed:
 lint:
 	npx eslint lib
 
-publish: check-committed lint
-	npm version prerelease
-	npm publish
+docs:
+	rm -rf docs
+	npx jsdoc -c jsdoc.json
 
 amend:
 	git commit -C HEAD -a --amend

--- a/README.md
+++ b/README.md
@@ -1,0 +1,31 @@
+# Factory+ Rx service client
+
+This module provides extensions to the ServiceClient class provided by
+`@amrc-factoryplus/service-client`. These extensions support prompt
+notification of changes to service state by using `rxjs` Observables.
+
+## Usage
+
+Import the RxClient class and create a client object. All parameters to
+the RxClient constructor are as for the base ServiceClient.
+
+```js
+import process from "process";
+import { RxClient, UUIDs } from "@amrc-factoryplus/rx-client";
+
+# Use configuration from the environment
+const client = new RxClient({ env: process.env });
+
+# Use explicit configuration
+const client = new RxClient({
+    directory_url:  "https://directory.my-fplus.example",
+    username:       "...",
+    password:       "...",
+    verbose:        "ALL",
+});
+
+# Create and subscribe to an Observable
+const sub = client.ConfigDB
+    .search_app(UUIDs.App.Info)
+    .subscribe(val => console.log(val.toJS()));
+```

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,0 +1,25 @@
+import globals from "globals";
+import js from "@eslint/js";
+
+export default [
+    js.configs.recommended,
+
+    {
+        languageOptions: {
+            globals: {
+                ...globals.node,
+            },
+
+            ecmaVersion: "latest",
+            sourceType: "module",
+        },
+
+        rules: {
+            "no-unreachable": "warn",
+            "no-unused-vars": ["warn", {
+                args:           "none",
+                caughtErrors:   "none",
+            }],
+        },
+    },
+];

--- a/jsdoc.json
+++ b/jsdoc.json
@@ -1,0 +1,11 @@
+{
+    "source": {
+        "include": ["lib"]
+    },
+    "opts": {
+        "destination": "docs",
+        "readme": "README.md",
+        "recurse": true
+    },
+    "plugins": ["plugins/markdown"]
+}

--- a/lib/configdb.js
+++ b/lib/configdb.js
@@ -4,12 +4,7 @@
  * Copyright 2024 University of Sheffield
  */
 
-import * as rx      from "rxjs";
-
-import {
-    Interfaces, ServiceError, UUIDs
-}                   from "@amrc-factoryplus/service-client";
-import * as rxx     from "@amrc-factoryplus/rx-util";
+import { Interfaces } from "@amrc-factoryplus/service-client";
 
 import { NotifyV2 } from "./notify-v2.js";
 
@@ -21,7 +16,8 @@ export class ConfigDB extends Interfaces.ConfigDB {
     constructor (fplus) {
         super(fplus);
 
-        /** A NotifyV2 object for the ConfigDB service. */
+        /** A NotifyV2 object for the ConfigDB service.
+         * @type NotifyV2 */
         this.notify = new NotifyV2(this);
     }
 

--- a/lib/configdb.js
+++ b/lib/configdb.js
@@ -13,21 +13,55 @@ import * as rxx     from "@amrc-factoryplus/rx-util";
 
 import { NotifyV2 } from "./notify-v2.js";
 
+/** Extended ConfigDB interface class.
+ * This supports all the methods from the base ConfigDB service
+ * interface as well as methods to access the notify API.
+ */
 export class ConfigDB extends Interfaces.ConfigDB {
     constructor (fplus) {
         super(fplus);
 
+        /** A NotifyV2 object for the ConfigDB service. */
         this.notify = new NotifyV2(this);
     }
 
+    /** Watch a particular config entry.
+     * Returns an Observable. This emits a value every time the config
+     * entry changes. The sequence will emit `null` when the entry is
+     * inaccessible.
+     * @param app An Application UUID.
+     * @param obj An object UUID.
+     */
     watch_config (app, obj) {
         return this.notify.watch(`v1/app/${app}/object/${obj}`);
     }
 
+    /** List the configs for an Application.
+     * Returns an Observable. This emits an Array every time the set of
+     * configs for this Application changes. If the Application is
+     * inaccessible the sequence emits `null`.
+     * @param app The Application to watch.
+     */
     watch_list (app) {
         return this.notify.watch(`v1/app/${app}/object/`);
     }
 
+    /** Run a notify SEARCH query over an application.
+     * Returns an Observable of immutable Maps. Each Map contains an
+     * entry for every selected config under the chosen Application.
+     * Whenever any selected config entry changes, the sequence will
+     * emit a new complete Map.
+     *
+     * If the application does not exist, an empty Map will be emitted.
+     * If we receive errors from the SEARCH operation, no new Maps will
+     * be emitted.
+     *
+     * The filter is an object matched against the values of the configs
+     * to limit those that are returned.
+     *
+     * @param app An Application UUID.
+     * @param filter An object to filter the results against.
+     */
     search_app (app, filter) {
         return this.notify.search(`v1/app/${app}/object/`, filter);
     }

--- a/lib/configdb.js
+++ b/lib/configdb.js
@@ -1,0 +1,39 @@
+/*
+ * Factory+ Rx interface
+ * ConfigDB notify
+ * Copyright 2024 University of Sheffield
+ */
+
+import * as rx      from "rxjs";
+
+import {
+    Interfaces, ServiceError, UUIDs
+}                   from "@amrc-factoryplus/service-client";
+import * as rxx     from "@amrc-factoryplus/rx-util";
+
+import { NotifyV2 } from "./notify-v2.js";
+
+export class ConfigDB extends Interfaces.ConfigDB {
+    constructor (fplus) {
+        super(fplus);
+
+        this.notify = new NotifyV2(this);
+    }
+
+    watch_url (url) {
+        return rxx.rx(
+            this.notify.request({ method: "WATCH", request: { url } }),
+            rx.map(u => u.response),
+            rx.map(res => {
+                if (res.status == 200 || res.status == 201)
+                    return res.body;
+                if (res.status == 404)
+                    return null;
+                this.throw(`Error watching ${url}`, res.status);
+            }));
+    }
+
+    watch_config (app, obj) {
+        return this.watch_url(`v1/app/${app}/object/${obj}`);
+    }
+}

--- a/lib/configdb.js
+++ b/lib/configdb.js
@@ -20,20 +20,15 @@ export class ConfigDB extends Interfaces.ConfigDB {
         this.notify = new NotifyV2(this);
     }
 
-    watch_url (url) {
-        return rxx.rx(
-            this.notify.request({ method: "WATCH", request: { url } }),
-            rx.map(u => u.response),
-            rx.map(res => {
-                if (res.status == 200 || res.status == 201)
-                    return res.body;
-                if (res.status == 404)
-                    return null;
-                this.throw(`Error watching ${url}`, res.status);
-            }));
+    watch_config (app, obj) {
+        return this.notify.watch(`v1/app/${app}/object/${obj}`);
     }
 
-    watch_config (app, obj) {
-        return this.watch_url(`v1/app/${app}/object/${obj}`);
+    watch_list (app) {
+        return this.notify.watch(`v1/app/${app}/object/`);
+    }
+
+    search_app (app, filter) {
+        return this.notify.search(`v1/app/${app}/object/`, filter);
     }
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,4 +1,9 @@
 export { UUIDs } from "@amrc-factoryplus/service-client";
 
+/** Re-export of the UUIDs constant from `service-client`.
+ * @name UUIDs
+ * @constant
+ */
+
 export * as Interfaces from "./interfaces.js";
 export { RxClient } from "./rx-client.js";

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,0 +1,4 @@
+export { UUIDs } from "@amrc-factoryplus/service-client";
+
+export * as Interfaces from "./interfaces.js";
+export { RxClient } from "./rx-client.js";

--- a/lib/interfaces.js
+++ b/lib/interfaces.js
@@ -1,0 +1,1 @@
+export { ConfigDB } from "./configdb.js";

--- a/lib/interfaces.js
+++ b/lib/interfaces.js
@@ -1,1 +1,11 @@
+/**
+ * Service interface classes.
+ *
+ * These are extended from the corresponding interface classes provided
+ * by `@amrc-factoryplus/service-client`.
+ * @name Interfaces
+ * @namespace
+ */
+
 export { ConfigDB } from "./configdb.js";
+

--- a/lib/maybe.js
+++ b/lib/maybe.js
@@ -10,24 +10,63 @@
  * good names.
  */
 
+/**
+ * An exception class representing an HTTP error.
+ */
 export class HTTPError extends Error {
+    /** Create an HTTPError.
+     * @param status An HTTP status code
+     */
     constructor (status) {
         super(`HTTP error ${status}`);
         this.status = status;
     }
 }
 
+function _abstract {
+    throw new TypeError("Base Maybe is an abstract type");
+}
+
+/**
+ * A class representing success, failure or no-result.
+ *
+ * This class is a monad, related to Optional, which also allows the
+ * possibility of an error result. The `map` and `flatMap` methods allow
+ * processing a successful result without affecting an empty or error
+ * result. The `handle` method allows handling errors.
+ */
 export class Maybe {
+    /** Create a successful Maybe.
+     * @param val The value in the Maybe.
+     */
     static success (val) { return new Success(val); }
+    /** Create an empty Maybe. */
     static empty () { return new Empty(); }
+    /** Create a Maybe representing an error.
+     * @param err A value representing the error, normally an Error.
+     */
     static error (err) { return new Failure(err); }
 
-    static of (v) {
-        return v == null ? Maybe.empty() : Maybe.success(v);
+    /** Create a Maybe.
+     * If passed a defined error, creates an error Maybe.
+     * If passed a null or undefined value, creates an empty Maybe.
+     * Otherwise creates a successful Maybe.
+     *
+     * @param val The value to examine if no error.
+     * @param err A error, or undefined.
+     */
+    static of (val, err) {
+        return err === undefined
+            ? val == null ? Maybe.empty() : Maybe.success(val)
+            : Maybe.error(err);
     }
-    static ofError (v, e) {
-        return e ? Maybe.error(e) : Maybe.of(v);
-    }
+    /** Create a Maybe from an HTTP response or similar.
+     * Expects an object with a numeric `status` property. If this is
+     * less than 300, returns success. If this is equal to 404, returns
+     * empty. Otherwise returns error, using the HTTPError exception.
+     *
+     * @param res An object containing an HTTP status code.
+     */
     static ofHttp (res) {
         if (res.status < 300)
             return Maybe.of(res);
@@ -36,21 +75,98 @@ export class Maybe {
         return Maybe.error(new HTTPError(res.status));
     }
 
+    /** Is this is a successful result? */
     get isOK ()     { return false; }
+    /** Is this an empty result? */
     get isEmpty ()  { return false; }
+    /** Is this an error result? */
     get isError ()  { return false; }
 
+    /** Transform a successful result to another Maybe.
+     * An empty or error result is returned unchanged.
+     *
+     * @param fn A function from value to Maybe.
+     */
+    flatMap (fn) { return _abstract(); }
+
+    /** Transform an empty result to another Maybe.
+     * A success or error result is returned unchanged.
+     *
+     * @param fn A function from `()` to Maybe.
+     */
+    or (fn) { return _abstract(); }
+
+    /** Transform an error result to another Maybe.
+     * A success or empty result is returned unchanged.
+     * If a class selector is supplied, only errors which are
+     * `instanceof` that class are handled. Other errors are returned
+     * unchanged.
+     *
+     * @param cls A class selector, or `null`.
+     * @param fn A function from error to Maybe.
+     */
+    handle (cls, fn) { return _abstract(); }
+
+    /** Filter successful result.
+     * A success result will be passed to the predicate function; if
+     * this returns `false` then an empty result will be returned.
+     * Otherwise the Maybe is returned unchanged.
+     *
+     * @param pred A predicate function to test a success result
+     */
     filter (pred) {
         return this.flatMap(b => pred(b) ? this : Maybe.empty());
     }
 
+    /** Transform successful result.
+     * A success result will be passed to the mapping function and a new
+     * success result returned. Empty and error results are unchanged. A
+     * `null` or `undefined` return value from the mapping function will
+     * return an empty Maybe.
+     *
+     * @param fn The mapping function.
+     */
     map (fn) {
         return this.flatMap(b => Maybe.of(fn(b)));
     }
 
+    /** Transform error result.
+     * An error result will be matched against the error class and then
+     * passed to the mapping function; the return value will be
+     * re-wrapped in an error Maybe. Success and empty Maybes will be
+     * returned unchanged.
+     *
+     * @param cls A class selector, or `null`.
+     * @param fn The mapping function.
+     */
     mapError (cls, fn) {
         return this.handle(cls, e => Maybe.error(fn(e)));
     }
+
+    /** Extract value from Maybe.
+     * A success Maybe returns its value. An empty Maybe returns
+     * `undefined`. An error Maybe throws its error.
+     */
+    get () { return _abstract(); }
+
+    /** Extract value or default.
+     * A success Maybe returns its value. An empty Maybe returns the
+     * supplied value. An error Maybe throws its error.
+     */
+    orElse () { return _abstract(); }
+
+    /** Call function for success or failure.
+     * On success, the first function is called with the Maybe's value.
+     * On empty, the second function is called with no arguments. On
+     * error the second function is called with the error.
+     *
+     * The second function is optional. Omitting it will return
+     * `undefined`.
+     *
+     * @param success Function to call on success.
+     * @param failure Function to call on empty or error.
+     */
+    ifOK (success, failure) { return _abstract(); }
 }
 
 class Success extends Maybe {
@@ -92,7 +208,7 @@ class Failure extends Maybe {
     or (fn)         { return this; }
 
     handle (cls, fn) {
-        if (this.error instanceof cls)
+        if (!cls || this.error instanceof cls)
             return fn(this.error);
         return this;
     }

--- a/lib/maybe.js
+++ b/lib/maybe.js
@@ -23,7 +23,7 @@ export class HTTPError extends Error {
     }
 }
 
-function _abstract {
+function _abstract () {
     throw new TypeError("Base Maybe is an abstract type");
 }
 

--- a/lib/maybe.js
+++ b/lib/maybe.js
@@ -1,0 +1,103 @@
+/*
+ * Factory+ Rx client
+ * HTTP Maybe monad
+ * Copyright 2024 University of Sheffield
+ */
+
+/* XXX I don't entirely like the name conflict with RxJava's Maybe,
+ * which is the sequence version of this, nor with Haskell's Maybe,
+ * which is Java's Optional. There are too many concepts and not enough
+ * good names.
+ */
+
+export class HTTPError extends Error {
+    constructor (status) {
+        super(`HTTP error ${status}`);
+        this.status = status;
+    }
+}
+
+export class Maybe {
+    static success (val) { return new Success(val); }
+    static empty () { return new Empty(); }
+    static error (err) { return new Failure(err); }
+
+    static of (v) {
+        return v == null ? Maybe.empty() : Maybe.success(v);
+    }
+    static ofError (v, e) {
+        return e ? Maybe.error(e) : Maybe.of(v);
+    }
+    static ofHttp (res) {
+        if (res.status < 300)
+            return Maybe.of(res);
+        if (res.status == 404)
+            return Maybe.empty();
+        return Maybe.error(new HTTPError(res.status));
+    }
+
+    get isOK ()     { return false; }
+    get isEmpty ()  { return false; }
+    get isError ()  { return false; }
+
+    filter (pred) {
+        return this.flatMap(b => pred(b) ? this : Maybe.empty());
+    }
+
+    map (fn) {
+        return this.flatMap(b => Maybe.of(fn(b)));
+    }
+
+    mapError (cls, fn) {
+        return this.handle(cls, e => Maybe.error(fn(e)));
+    }
+}
+
+class Success extends Maybe {
+    constructor (val) {
+        super();
+        this.value = val;
+    }
+
+    get isOK ()     { return true; }
+
+    flatMap (fn)    { return fn(this.value); }
+    or (fn)         { return this; }
+    handle (c, fn)  { return this; }
+
+    get ()          { return this.value; }
+    orElse (v)      { return this.value; }
+    ifOK (fn)       { return fn(this.value); }
+}
+
+class Empty extends Maybe {
+    get isEmpty ()  { return true; }
+
+    flatMap (fn)    { return this; }
+    or (fn)         { return fn(); }
+    handle (c, fn)  { return this; }
+
+    get ()          { return; }
+    orElse (v)      { return v; }
+    ifOK (fn, err)  { return err?.(); }
+}
+
+class Failure extends Maybe {
+    constructor (err) {
+        super();
+        this.error = err;
+    }
+
+    flatMap (fn)    { return this; }
+    or (fn)         { return this; }
+
+    handle (cls, fn) {
+        if (this.error instanceof cls)
+            return fn(this.error);
+        return this;
+    }
+
+    get ()          { throw this.error; }
+    orElse ()       { throw this.error; }
+    ifOK (fn, err)  { return err?.(this.error); }
+}

--- a/lib/notify-v2.js
+++ b/lib/notify-v2.js
@@ -1,0 +1,84 @@
+/*
+ * Factory+ Rx interface
+ * notify/v2 interface
+ * Copyright 2024 University of Sheffield
+ */
+
+import { v4 as uuidv4 } from "uuid";
+import * as rx from "rxjs";
+
+import * as rxx from "@amrc-factoryplus/rx-util";
+
+export class NotifyV2 {
+    constructor (service) {
+        this.service = service;
+
+        this.log = this.service.log;
+        this.notify = this.build_notify();
+    }
+
+    handle_notify_ws (ws) {
+        const error = rxx.rx(
+            rx.fromEvent(ws, "error"),
+            rx.tap(e => this.log("Notify WS error: %o", e)));
+        const stopped = rx.merge(error, rx.fromEvent(ws, "close"));
+        const msgs = rxx.rx(
+            rx.fromEvent(ws, "message"),
+            rx.map(m => JSON.parse(m.data)),
+            rx.tap(v => this.log("Notify update: %o", v)),
+            rx.share());
+        const send = msg => {
+            if (ws.readyState > ws.constructor.OPEN) {
+                this.log("Ignoring send to closing WS");
+                return;
+            }
+            this.log("Sending request %o", msg);
+            ws.send(JSON.stringify(msg));
+        };
+
+        return rxx.rx(
+            rx.merge(rx.of([send, msgs]), error),
+            rx.finalize(() => {
+                this.log("Closing notify WS");
+                ws.close();
+            }),
+            rx.takeUntil(stopped));
+    }
+
+    build_notify () {
+        return rxx.rx(
+            rx.defer(() => this.service.websocket("notify/v2")),
+            rx.catchError(e => {
+                this.log("Notify WS connect error: %s", e);
+                return rx.EMPTY;
+            }),
+            rx.flatMap(ws => this.handle_notify_ws(ws)),
+            rx.endWith(null),
+            rx.repeat({ delay: () => rx.timer(5000 + Math.random()*2000) }),
+            rx.tap(v => this.log("Notify socket %s", v ? "open" : "closed")),
+            rxx.shareLatest(),
+            rx.filter(w => w));
+    }
+    
+    /* This accepts a request structure, without a UUID. When the
+     * returned seq is subscribed to, it generates a new UUID for the
+     * request, sends the request, and returns a sequence of the
+     * responses. */
+    request (req) {
+        return rxx.rx(
+            this.notify,
+            rx.switchMap(([send, updates]) => {
+                const uuid = uuidv4();
+                return rxx.rx(
+                    updates,
+                    rx.filter(u => u.uuid == uuid),
+                    rx.tap(u => u.status < 400 || u.status == 410
+                        || this.log("Notify error: %s", u.status)),
+                    rx.takeWhile(u => u.status < 400),
+                    rx.tap({
+                        subscribe:      () => send({ ...req, uuid }),
+                        unsubscribe:    () => send({ method: "CLOSE", uuid }),
+                    }));
+            }));
+    }
+}

--- a/lib/notify-v2.js
+++ b/lib/notify-v2.js
@@ -16,6 +16,7 @@ function st_ok (res) {
     return res.status < 300;
 }
 
+/** Provides access to the `notify/v2` API. */
 export class NotifyV2 {
     /** Build a notify/v2 connection.
      *
@@ -28,7 +29,7 @@ export class NotifyV2 {
         this.notify = this.build_notify();
     }
 
-    /** @name NotifyV2#notify
+    /**
      * A sequence of WebSocket connections.
      * This property contains an Observable. While subscriptions to that
      * sequence exist it will maintain an open connection to the
@@ -47,6 +48,8 @@ export class NotifyV2 {
      *
      * Both inner and outer sequences are 'hot'. The outer sequence will
      * return immediately the current open WS, if any, on subscription.
+     *
+     * @name NotifyV2#notify
      */
 
     handle_notify_ws (ws) {

--- a/lib/notify-v2.js
+++ b/lib/notify-v2.js
@@ -10,6 +10,8 @@ import * as rx              from "rxjs";
 
 import * as rxx             from "@amrc-factoryplus/rx-util";
 
+import { Maybe }            from "./maybe.js";
+
 function st_ok (res) {
     return res.status < 300;
 }
@@ -87,31 +89,73 @@ export class NotifyV2 {
             }));
     }
 
-    watch (request) {
+    /** Make a WATCH notify request and return a sequence of the HTTP
+     * responses. Returns an Observable of Maybe objects which, if
+     * OK, contain HTTP responses.
+     *
+     * @param request An HTTP request structure
+     */
+    watch_full (request) {
         if (typeof request == "string")
             request = { url: request };
         return rxx.rx(
             this.request({ method: "WATCH", request }),
             rx.map(u => u.response),
-            rx.map(res => {
-                if (st_ok(res))
-                    return res.body;
-                if (res.status == 404)
-                    return null;
-                this.throw(`Error watching ${url}`, res.status);
-            }));
+            rx.map(Maybe.ofHttp));
     }
 
-    search (parent, filter) {
+    /** Make a WATCH notify request and return a sequence of the
+     * results. Returns an Observable of HTTP response bodies;
+     * unsuccessful responses are all mapped to `null`.
+     *
+     * @param request An HTTP request structure
+     */
+    watch (request) {
+        return rxx.rx(
+            this.watch_full(request),
+            rx.map(r => r.ifOK(r => r.body, e => null)));
+    }
+
+    /** Make a SEARCH notify request and return a sequence of the HTTP
+     * responses returned. Returns an Observable of Maybes. Each new
+     * Maybe indicates the search results have changed. Successful
+     * Maybes contain an immutable Map mapping from child path to a
+     * Maybe for that child.
+     *
+     * @param parent The parent URL path to search from.
+     * @param filter An object to filter the results.
+     */
+    search_full (parent, filter) {
         return rxx.rx(
             this.request({ method: "SEARCH", parent, filter }),
-            rx.scan((m, u) => u.child 
-                ? st_ok(u.response)
-                    ? m.set(u.child, u.response.body)
-                    : m.delete(u.child)
-                : st_ok(u.response)
-                    ? imm.Map(u.children).map(r => r.body)
-                    : imm.Map(),
-                imm.Map()));
+            rx.map(u => [u.child,
+                Maybe.ofHttp(u.response),
+                Maybe.of(u.children)
+                    .map(imm.Map)
+                    .map(m => m.map(Maybe.ofHttp))]),
+            rx.scan((st, [child, res, children]) => child
+                ? st.map(m => res.isEmpty ? m.delete(child) : m.set(child, res))
+                : res.flatMap(r => children),
+                Maybe.empty()));
     } 
+
+    /** Make a SEARCH notify request and return a sequence of the
+     * response bodies. Returns an Observable of immutable Maps.
+     * The Maps map from child path to the response body for that child.
+     * Updates where the parent URL returns an error will be suppressed.
+     * Children returning an error response will be omitted from the
+     * Map.
+     *
+     * @param parent The parent URL path to search from.
+     * @param filter An object to filter the results.
+     */
+    search (parent, filter) {
+        return rxx.rx(
+            this.search_full(parent, filter),
+            rx.flatMap(res => res
+                .map(kids => kids
+                    .filter(r => r.isOK)
+                    .map(r => r.get().body))
+                .ifOK(rx.of, e => rx.EMPTY)));
+    }
 }

--- a/lib/notify-v2.js
+++ b/lib/notify-v2.js
@@ -17,12 +17,37 @@ function st_ok (res) {
 }
 
 export class NotifyV2 {
+    /** Build a notify/v2 connection.
+     *
+     * @param service The ServiceInterface we should connect to.
+     */
     constructor (service) {
         this.service = service;
 
         this.log = this.service.log;
         this.notify = this.build_notify();
     }
+
+    /** @name NotifyV2#notify
+     * A sequence of WebSocket connections.
+     * This property contains an Observable. While subscriptions to that
+     * sequence exist it will maintain an open connection to the
+     * `notify/v2` WebSocket endpoint on our service API.
+     *
+     * Each time a new WS is successfully opened, a pair `[send, msgs]`
+     * will be sent down the sequence. `send` is a function which will
+     * JSON-encode its argument and send it up the WS to the service.
+     * `msgs` is another sequence, containing JSON-decoded messages from
+     * the notify service.
+     *
+     * If the WS closes for any reason, the `msgs` sequence will end,
+     * with an error if appropriate. The outer `notify` sequence will
+     * not end, it will attempt to reconnect and, when successful, a new
+     * pair will be sent down the outer sequence.
+     *
+     * Both inner and outer sequences are 'hot'. The outer sequence will
+     * return immediately the current open WS, if any, on subscription.
+     */
 
     handle_notify_ws (ws) {
         const error = rxx.rx(
@@ -67,10 +92,22 @@ export class NotifyV2 {
             rx.filter(w => w));
     }
     
-    /* This accepts a request structure, without a UUID. When the
-     * returned seq is subscribed to, it generates a new UUID for the
-     * request, sends the request, and returns a sequence of the
-     * responses. */
+    /** Make a request and return all the responses.
+     * 
+     * This accepts a request structure without the `uuid` key, and
+     * returns an Observable. When that sequence is subscribed to the
+     * request will be assigned a UUID and sent to the notify WS. Any
+     * responses returned will be passed down the sequence.
+     *
+     * If our connection to the notify WS is lost, the request will be
+     * re-sent (with a new UUID) once the connection is reestablished.
+     * The new 'initial' responses can be identified by their 201
+     * subscription status code.
+     *
+     * When the subscription is closed a CLOSE will be sent.
+     *
+     * @param req A notify request structure, without `uuid`.
+     */
     request (req) {
         return rxx.rx(
             this.notify,
@@ -91,9 +128,9 @@ export class NotifyV2 {
 
     /** Make a WATCH notify request and return a sequence of the HTTP
      * responses. Returns an Observable of Maybe objects which, if
-     * OK, contain HTTP responses.
+     * successful, contain HTTP responses.
      *
-     * @param request An HTTP request structure
+     * @param request An HTTP request structure.
      */
     watch_full (request) {
         if (typeof request == "string")
@@ -108,7 +145,7 @@ export class NotifyV2 {
      * results. Returns an Observable of HTTP response bodies;
      * unsuccessful responses are all mapped to `null`.
      *
-     * @param request An HTTP request structure
+     * @param request An HTTP request structure.
      */
     watch (request) {
         return rxx.rx(

--- a/lib/notify-v2.js
+++ b/lib/notify-v2.js
@@ -4,10 +4,15 @@
  * Copyright 2024 University of Sheffield
  */
 
-import { v4 as uuidv4 } from "uuid";
-import * as rx from "rxjs";
+import * as imm             from "immutable";
+import { v4 as uuidv4 }     from "uuid";
+import * as rx              from "rxjs";
 
-import * as rxx from "@amrc-factoryplus/rx-util";
+import * as rxx             from "@amrc-factoryplus/rx-util";
+
+function st_ok (res) {
+    return res.status < 300;
+}
 
 export class NotifyV2 {
     constructor (service) {
@@ -72,13 +77,41 @@ export class NotifyV2 {
                 return rxx.rx(
                     updates,
                     rx.filter(u => u.uuid == uuid),
-                    rx.tap(u => u.status < 400 || u.status == 410
+                    rx.tap(u => st_ok(u) || u.status == 410
                         || this.log("Notify error: %s", u.status)),
-                    rx.takeWhile(u => u.status < 400),
+                    rx.takeWhile(st_ok),
                     rx.tap({
                         subscribe:      () => send({ ...req, uuid }),
                         unsubscribe:    () => send({ method: "CLOSE", uuid }),
                     }));
             }));
     }
+
+    watch (request) {
+        if (typeof request == "string")
+            request = { url: request };
+        return rxx.rx(
+            this.request({ method: "WATCH", request }),
+            rx.map(u => u.response),
+            rx.map(res => {
+                if (st_ok(res))
+                    return res.body;
+                if (res.status == 404)
+                    return null;
+                this.throw(`Error watching ${url}`, res.status);
+            }));
+    }
+
+    search (parent, filter) {
+        return rxx.rx(
+            this.request({ method: "SEARCH", parent, filter }),
+            rx.scan((m, u) => u.child 
+                ? st_ok(u.response)
+                    ? m.set(u.child, u.response.body)
+                    : m.delete(u.child)
+                : st_ok(u.response)
+                    ? imm.Map(u.children).map(r => r.body)
+                    : imm.Map(),
+                imm.Map()));
+    } 
 }

--- a/lib/rx-client.js
+++ b/lib/rx-client.js
@@ -1,0 +1,15 @@
+/*
+ * Factory+ client library, Rx version
+ * Copyright 2024 University of Sheffield
+ */
+
+import { ServiceClient } from "@amrc-factoryplus/service-client";
+
+import * as SI from "./interfaces.js";
+
+export class RxClient extends ServiceClient {
+}
+
+RxClient.define_interfaces(
+    ["ConfigDB", SI.ConfigDB, ``],
+);

--- a/lib/rx-client.js
+++ b/lib/rx-client.js
@@ -7,9 +7,23 @@ import { ServiceClient } from "@amrc-factoryplus/service-client";
 
 import * as SI from "./interfaces.js";
 
+/**
+ * Extends ServiceClient with Rx operations
+ *
+ * This class extends ServiceClient from
+ * @amrc-factoryplus/service-client. The service interfaces provide
+ * additional functionality relying on rxjs.
+ */
 export class RxClient extends ServiceClient {
 }
 
 RxClient.define_interfaces(
     ["ConfigDB", SI.ConfigDB, ``],
 );
+
+/** @name RxClient#ConfigDB
+ * ConfigDB extended service interface.
+ * This property returns an Interfaces.ConfigDB object. This class
+ * extends the base ConfigDB interface class from `service-client` with
+ * additional methods for change-notify.
+ */

--- a/lib/rx-client.js
+++ b/lib/rx-client.js
@@ -8,10 +8,10 @@ import { ServiceClient } from "@amrc-factoryplus/service-client";
 import * as SI from "./interfaces.js";
 
 /**
- * Extends ServiceClient with Rx operations
+ * Extends ServiceClient with Rx operations.
  *
  * This class extends ServiceClient from
- * @amrc-factoryplus/service-client. The service interfaces provide
+ * `@amrc-factoryplus/service-client`. The service interfaces provide
  * additional functionality relying on rxjs.
  */
 export class RxClient extends ServiceClient {
@@ -21,9 +21,11 @@ RxClient.define_interfaces(
     ["ConfigDB", SI.ConfigDB, ``],
 );
 
-/** @name RxClient#ConfigDB
+/**
  * ConfigDB extended service interface.
- * This property returns an Interfaces.ConfigDB object. This class
- * extends the base ConfigDB interface class from `service-client` with
- * additional methods for change-notify.
+ * This object extends the base ConfigDB interface from `service-client`
+ * with additional methods for change-notify.
+ *
+ * @name RxClient#ConfigDB
+ * @type Interfaces.ConfigDB
  */

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,13 @@
         "immutable": "^5.0.0-rc.2",
         "rxjs": "^7.8.1",
         "uuid": "^11.0.2"
+      },
+      "devDependencies": {
+        "@eslint/eslintrc": "^3.1.0",
+        "@eslint/js": "^9.14.0",
+        "eslint": "^9.14.0",
+        "globals": "^15.12.0",
+        "jsdoc": "^4.0.4"
       }
     },
     "node_modules/@amrc-factoryplus/rx-util": {
@@ -56,6 +63,39 @@
         "uuid": "dist/bin/uuid"
       }
     },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.25.9.tgz",
+      "integrity": "sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz",
+      "integrity": "sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.26.2",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.2.tgz",
+      "integrity": "sha512-DWMCZH9WA4Maitz2q21SRKHo9QXZxkDsbNZoVD62gusNtNBBqDg9i7uOhASfTfIGNzW+O+r7+jAlM8dwphcJKQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.26.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/@babel/runtime": {
       "version": "7.26.0",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.0.tgz",
@@ -65,6 +105,231 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.26.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.0.tgz",
+      "integrity": "sha512-Z/yiTPj+lDVnF7lWeKCIJzaIkI0vYO87dMpZ4bg4TDrFe4XXLFWL1TbXU27gBP3QccxV9mZICCrnjnYlJjXHOA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.25.9",
+        "@babel/helper-validator-identifier": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.1.tgz",
+      "integrity": "sha512-s3O3waFUrMV8P/XaF/+ZTp1X9XBZW1a4B97ZnjQF2KYWaFD2A8KyFBsrsfSjEmjn3RGWAIuvlneuZm3CUK3jbA==",
+      "dev": true,
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.1.tgz",
+      "integrity": "sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==",
+      "dev": true,
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.18.0.tgz",
+      "integrity": "sha512-fTxvnS1sRMu3+JjXwJG0j/i4RT9u4qJ+lqS/yCGap4lH4zZGzQ7tu+xZqQmcMZq5OBZDL4QRxQzRjkWcGt8IVw==",
+      "dev": true,
+      "dependencies": {
+        "@eslint/object-schema": "^2.1.4",
+        "debug": "^4.3.1",
+        "minimatch": "^3.1.2"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.7.0.tgz",
+      "integrity": "sha512-xp5Jirz5DyPYlPiKat8jaq0EmYvDXKKpzTbxXMpT9eqlRJkRKIz9AGMdlvYjih+im+QlhWrpvVjl8IPC/lHlUw==",
+      "dev": true,
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.1.0.tgz",
+      "integrity": "sha512-4Bfj15dVJdoy3RfZmmo86RK1Fwzn6SstsvK9JS+BaVKqC6QQQQyXekNaC+g+LKNgkQ+2VhGAzm6hO40AhMR3zQ==",
+      "dev": true,
+      "dependencies": {
+        "ajv": "^6.12.4",
+        "debug": "^4.3.2",
+        "espree": "^10.0.1",
+        "globals": "^14.0.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.0",
+        "minimatch": "^3.1.2",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/globals": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "9.14.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.14.0.tgz",
+      "integrity": "sha512-pFoEtFWCPyDOl+C6Ift+wC7Ro89otjigCf5vcuWqWgqNSQbRrpjSvdeE6ofLz4dHmyxD5f7gIdGT4+p36L6Twg==",
+      "dev": true,
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.4.tgz",
+      "integrity": "sha512-BsWiH1yFGjXXS2yvrf5LyuoSIIbPrGUWob917o+BTKuZ7qJdxX8aJLRxs1fS9n6r7vESrq1OUqb68dANcFXuQQ==",
+      "dev": true,
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.2.tgz",
+      "integrity": "sha512-CXtq5nR4Su+2I47WPOlWud98Y5Lv8Kyxp2ukhgFx/eW6Blm18VXJO5WuQylPugRo8nbluoi6GvvxBLqHcvqUUw==",
+      "dev": true,
+      "dependencies": {
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
+      "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+      "dev": true,
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.6",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.6.tgz",
+      "integrity": "sha512-YuI2ZHQL78Q5HbhDiBA1X4LmYdXCKCMQIfw0pw7piHJwyREFebJUvrQN4cMssyES6x+vfUbx1CIpaQUKYdQZOw==",
+      "dev": true,
+      "dependencies": {
+        "@humanfs/core": "^0.19.1",
+        "@humanwhocodes/retry": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node/node_modules/@humanwhocodes/retry": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.3.1.tgz",
+      "integrity": "sha512-JBxkERygn7Bv/GbN5Rv8Ul6LVknS+5Bp6RgDC/O8gEBU/yeH5Ui5C/OlWrTb6qct7LjjfT6Re2NxB0ln0yYybA==",
+      "dev": true,
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.1.tgz",
+      "integrity": "sha512-c7hNEllBlenFTHBky65mhq8WD2kbN9Q6gk0bTk8lSBvc554jpXSkST1iePudpt7+A/AQvuHs9EMqjHDXMY1lrA==",
+      "dev": true,
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@jsdoc/salty": {
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/@jsdoc/salty/-/salty-0.2.8.tgz",
+      "integrity": "sha512-5e+SFVavj1ORKlKaKr2BmTOekmXbelU7dC0cDkQLqag7xfuTPuGMUFx7KWJuv4bYZrTsoL2Z18VVCOKYxzoHcg==",
+      "dev": true,
+      "dependencies": {
+        "lodash": "^4.17.21"
+      },
+      "engines": {
+        "node": ">=v12.0.0"
       }
     },
     "node_modules/@protobufjs/aspromise": {
@@ -147,6 +412,12 @@
         "node": ">=14.16"
       }
     },
+    "node_modules/@types/estree": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
+      "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
+      "dev": true
+    },
     "node_modules/@types/http-cache-semantics": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.4.tgz",
@@ -154,10 +425,38 @@
       "optional": true,
       "peer": true
     },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true
+    },
+    "node_modules/@types/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
+      "dev": true
+    },
     "node_modules/@types/long": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
       "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA=="
+    },
+    "node_modules/@types/markdown-it": {
+      "version": "14.1.2",
+      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.2.tgz",
+      "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
+      "dev": true,
+      "dependencies": {
+        "@types/linkify-it": "^5",
+        "@types/mdurl": "^2"
+      }
+    },
+    "node_modules/@types/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
+      "dev": true
     },
     "node_modules/@types/node": {
       "version": "22.8.6",
@@ -195,6 +494,43 @@
         "node": ">=6.5"
       }
     },
+    "node_modules/acorn": {
+      "version": "8.14.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
+      "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
+      "dev": true,
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "node_modules/ansi": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.1.tgz",
@@ -208,6 +544,21 @@
       "optional": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/are-we-there-yet": {
@@ -251,6 +602,12 @@
         "safe-buffer": "~5.1.0"
       }
     },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true
+    },
     "node_modules/axios": {
       "version": "0.21.4",
       "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
@@ -264,7 +621,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "optional": true
+      "devOptional": true
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -373,13 +730,13 @@
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
       "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
-      "optional": true
+      "devOptional": true
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "optional": true,
+      "devOptional": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -466,6 +823,15 @@
         "node": ">=14.16"
       }
     },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/camelcase": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
@@ -473,6 +839,18 @@
       "optional": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/catharsis": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/catharsis/-/catharsis-0.9.0.tgz",
+      "integrity": "sha512-prMTQVpcns/tzFgFVkVp6ak6RykZyWb3gu8ckUpd6YkTlacOd3DXGJjIpD4Q6zJirizvaiAjSSHlOsA+6sNh2A==",
+      "dev": true,
+      "dependencies": {
+        "lodash": "^4.17.15"
+      },
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/chainsaw": {
@@ -485,6 +863,22 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/chownr": {
@@ -552,6 +946,24 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
     "node_modules/commist": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/commist/-/commist-3.2.0.tgz",
@@ -561,7 +973,7 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "optional": true
+      "devOptional": true
     },
     "node_modules/concat-stream": {
       "version": "2.0.0",
@@ -631,6 +1043,35 @@
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "optional": true
     },
+    "node_modules/cross-spawn": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "dev": true,
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/cross-spawn/node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/debug": {
       "version": "4.3.7",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
@@ -694,6 +1135,12 @@
         "node": ">=4.0.0"
       }
     },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true
+    },
     "node_modules/defer-to-connect": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
@@ -749,6 +1196,186 @@
         "safe-buffer": "~5.1.0"
       }
     },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+      "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "9.14.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.14.0.tgz",
+      "integrity": "sha512-c2FHsVBr87lnUtjP4Yhvk4yEhKrQavGafRA/Se1ouse8PfbfC/Qh9Mxa00yWsZRlqeUB9raXip0aiiUZkgnr9g==",
+      "dev": true,
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.2.0",
+        "@eslint-community/regexpp": "^4.12.1",
+        "@eslint/config-array": "^0.18.0",
+        "@eslint/core": "^0.7.0",
+        "@eslint/eslintrc": "^3.1.0",
+        "@eslint/js": "9.14.0",
+        "@eslint/plugin-kit": "^0.2.0",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.0",
+        "@types/estree": "^1.0.6",
+        "@types/json-schema": "^7.0.15",
+        "ajv": "^6.12.4",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.2",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^8.2.0",
+        "eslint-visitor-keys": "^4.2.0",
+        "espree": "^10.3.0",
+        "esquery": "^1.5.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.2",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3",
+        "text-table": "^0.2.0"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.2.0.tgz",
+      "integrity": "sha512-PHlWUfG6lvPc3yvP5A4PNyBL1W8fkDUccmI21JUu/+GKZBoH/W5u6usENXUrWFRsyoW5ACUjFGgAFQp5gUlb/A==",
+      "dev": true,
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
+      "integrity": "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==",
+      "dev": true,
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/espree": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.3.0.tgz",
+      "integrity": "sha512-0QYC8b24HWY8zjRnDTL6RiHfDbAWn63qb4LMj1Z4b076A4une81+z03Kg7l7mn/48PUTqoLptSXez8oknU8Clg==",
+      "dev": true,
+      "dependencies": {
+        "acorn": "^8.14.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^4.2.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
+      "integrity": "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==",
+      "dev": true,
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/event-target-shim": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
@@ -765,6 +1392,24 @@
         "node": ">=0.8.x"
       }
     },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true
+    },
     "node_modules/fast-unique-numbers": {
       "version": "8.0.13",
       "resolved": "https://registry.npmjs.org/fast-unique-numbers/-/fast-unique-numbers-8.0.13.tgz",
@@ -777,11 +1422,58 @@
         "node": ">=16.1.0"
       }
     },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/file-uri-to-path": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
       "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
       "optional": true
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.1.tgz",
+      "integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==",
+      "dev": true
     },
     "node_modules/follow-redirects": {
       "version": "1.15.9",
@@ -903,6 +1595,30 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/globals": {
+      "version": "15.12.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-15.12.0.tgz",
+      "integrity": "sha512-1+gLErljJFhbOVyaetcwJiJ4+eLe45S2E7P5UiZ9xGfeq3ATQf5DOv9G7MH3gGbKQLkzmNh2DxfZwLdw+j6oTQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/got": {
       "version": "12.6.1",
       "resolved": "https://registry.npmjs.org/got/-/got-12.6.1.tgz",
@@ -945,7 +1661,7 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "optional": true
+      "devOptional": true
     },
     "node_modules/gssapi.js": {
       "version": "2.0.1",
@@ -957,6 +1673,15 @@
         "bindings": "^1.5.0",
         "cmake-js": "^6.1.0",
         "node-addon-api": "^1.7.2"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/has-unicode": {
@@ -1010,10 +1735,44 @@
         }
       ]
     },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/immutable": {
       "version": "5.0.0-rc.2",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.0.0-rc.2.tgz",
       "integrity": "sha512-iqmDkN2+LGR8DT/7ua4foLlf55Y40ZrDC31YJTJX7lv6yMLpU5pE4rOYnt3/T3Mw5tp/xFeMEwtqAURtVDkMQQ=="
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
+      "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
+      "dev": true,
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.19"
+      }
     },
     "node_modules/inflight": {
       "version": "1.0.6",
@@ -1046,6 +1805,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-fullwidth-code-point": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
@@ -1053,6 +1821,18 @@
       "optional": true,
       "dependencies": {
         "number-is-nan": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "dependencies": {
+        "is-extglob": "^2.1.1"
       },
       "engines": {
         "node": ">=0.10.0"
@@ -1074,7 +1854,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "optional": true
+      "devOptional": true
     },
     "node_modules/isomorphic-ws": {
       "version": "5.0.0",
@@ -1093,12 +1873,97 @@
         "url": "https://opencollective.com/js-sdsl"
       }
     },
+    "node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dev": true,
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/js2xmlparser": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/js2xmlparser/-/js2xmlparser-4.0.2.tgz",
+      "integrity": "sha512-6n4D8gLlLf1n5mNLQPRfViYzu9RATblzPEtm1SthMX1Pjao0r9YI9nw7ZIfRxQMERS87mcswrg+r/OYrPRX6jA==",
+      "dev": true,
+      "dependencies": {
+        "xmlcreate": "^2.0.4"
+      }
+    },
+    "node_modules/jsdoc": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-4.0.4.tgz",
+      "integrity": "sha512-zeFezwyXeG4syyYHbvh1A967IAqq/67yXtXvuL5wnqCkFZe8I0vKfm+EO+YEvLguo6w9CDUbrAXVtJSHh2E8rw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/parser": "^7.20.15",
+        "@jsdoc/salty": "^0.2.1",
+        "@types/markdown-it": "^14.1.1",
+        "bluebird": "^3.7.2",
+        "catharsis": "^0.9.0",
+        "escape-string-regexp": "^2.0.0",
+        "js2xmlparser": "^4.0.2",
+        "klaw": "^3.0.0",
+        "markdown-it": "^14.1.0",
+        "markdown-it-anchor": "^8.6.7",
+        "marked": "^4.0.10",
+        "mkdirp": "^1.0.4",
+        "requizzle": "^0.2.3",
+        "strip-json-comments": "^3.1.0",
+        "underscore": "~1.13.2"
+      },
+      "bin": {
+        "jsdoc": "jsdoc.js"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/jsdoc/node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "dev": true,
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/jsdoc/node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/json-buffer": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
-      "optional": true,
-      "peer": true
+      "devOptional": true
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true
     },
     "node_modules/jsonfile": {
       "version": "4.0.0",
@@ -1113,10 +1978,18 @@
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
       "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
-      "optional": true,
-      "peer": true,
+      "devOptional": true,
       "dependencies": {
         "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/klaw": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/klaw/-/klaw-3.0.0.tgz",
+      "integrity": "sha512-0Fo5oir+O9jnXu5EefYbVK+mHMBeEVEy2cmctR1O1NECcCkPRreJKrS6Qt/j3KC2C148Dfo9i3pCmCMsdqGr0g==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.1.9"
       }
     },
     "node_modules/lcid": {
@@ -1131,17 +2004,60 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+      "dev": true,
+      "dependencies": {
+        "uc.micro": "^2.0.0"
+      }
+    },
     "node_modules/listenercount": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/listenercount/-/listenercount-1.0.1.tgz",
       "integrity": "sha512-3mk/Zag0+IJxeDrxSgaDPy4zZ3w05PRZeJNnlWhzFz5OkX49J4krc+A8X2d2M69vGMBEX0uyl8M+W+8gH+kBqQ==",
       "optional": true
     },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "optional": true
+      "devOptional": true
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true
     },
     "node_modules/lodash.pad": {
       "version": "4.5.1",
@@ -1184,6 +2100,51 @@
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="
     },
+    "node_modules/markdown-it": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.0.tgz",
+      "integrity": "sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==",
+      "dev": true,
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "entities": "^4.4.0",
+        "linkify-it": "^5.0.0",
+        "mdurl": "^2.0.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^2.1.0"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.mjs"
+      }
+    },
+    "node_modules/markdown-it-anchor": {
+      "version": "8.6.7",
+      "resolved": "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-8.6.7.tgz",
+      "integrity": "sha512-FlCHFwNnutLgVTflOYHPW2pPcl2AACqVzExlkGQNsi4CJgqOHN7YTgDd4LuhgN1BFO3TS0vLAruV1Td6dwWPJA==",
+      "dev": true,
+      "peerDependencies": {
+        "@types/markdown-it": "*",
+        "markdown-it": "*"
+      }
+    },
+    "node_modules/marked": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
+      "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
+      "dev": true,
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
+      "dev": true
+    },
     "node_modules/memory-stream": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/memory-stream/-/memory-stream-0.0.3.tgz",
@@ -1210,7 +2171,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "optional": true,
+      "devOptional": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -1345,6 +2306,12 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true
+    },
     "node_modules/node-addon-api": {
       "version": "1.7.2",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-1.7.2.tgz",
@@ -1408,6 +2375,23 @@
       "resolved": "https://registry.npmjs.org/optional-js/-/optional-js-2.3.0.tgz",
       "integrity": "sha512-B0LLi+Vg+eko++0z/b8zIv57kp7HKEzaPJo7LowJXMUKYdf+3XJGu/cw03h/JhIOsLnP+cG5QnTHAuicjA5fMw=="
     },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/os-locale": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
@@ -1430,6 +2414,57 @@
         "node": ">=12.20"
       }
     },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -1437,6 +2472,24 @@
       "optional": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/process": {
@@ -1475,6 +2528,24 @@
       "bin": {
         "pbjs": "bin/pbjs",
         "pbts": "bin/pbts"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/punycode.js": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/quick-lru": {
@@ -1527,12 +2598,30 @@
       "resolved": "https://registry.npmjs.org/reinterval/-/reinterval-1.1.0.tgz",
       "integrity": "sha512-QIRet3SYrGp0HUHO88jVskiG6seqUGC5iAG7AwI/BV4ypGcuqk9Du6YQBUOUqm9c8pw1eyLoIaONifRua1lsEQ=="
     },
+    "node_modules/requizzle": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/requizzle/-/requizzle-0.2.4.tgz",
+      "integrity": "sha512-JRrFk1D4OQ4SqovXOgdav+K8EAhSB/LJZqCz8tbX0KObcdeM15Ss59ozWMBWmmINMagCwmqn4ZNryUGpBsl6Jw==",
+      "dev": true,
+      "dependencies": {
+        "lodash": "^4.17.21"
+      }
+    },
     "node_modules/resolve-alpn": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
       "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==",
       "optional": true,
       "peer": true
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/responselike": {
       "version": "3.0.0",
@@ -1597,6 +2686,27 @@
       "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
       "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
       "optional": true
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/sparkplug-payload": {
       "version": "1.0.3",
@@ -1663,6 +2773,18 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/tar": {
       "version": "4.4.19",
       "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.19.tgz",
@@ -1701,6 +2823,12 @@
       ],
       "optional": true
     },
+    "node_modules/text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
+      "dev": true
+    },
     "node_modules/traverse": {
       "version": "0.3.9",
       "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
@@ -1715,10 +2843,34 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/typedarray": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA=="
+    },
+    "node_modules/uc.micro": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+      "dev": true
+    },
+    "node_modules/underscore": {
+      "version": "1.13.7",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.7.tgz",
+      "integrity": "sha512-GMXzWtsc57XAtguZgaQViUOzs0KTkk8ojr3/xAxXLITqf/3EMwxC0inyETfDFjH/Krbhuep0HNbbjI9i/q3F3g==",
+      "dev": true
     },
     "node_modules/undici-types": {
       "version": "6.19.8",
@@ -1784,6 +2936,15 @@
         "util-deprecate": "~1.0.1"
       }
     },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
     "node_modules/url-join": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/url-join/-/url-join-0.0.1.tgz",
@@ -1829,6 +2990,15 @@
       },
       "engines": {
         "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/worker-timers": {
@@ -1901,6 +3071,12 @@
         }
       }
     },
+    "node_modules/xmlcreate": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/xmlcreate/-/xmlcreate-2.0.4.tgz",
+      "integrity": "sha512-nquOebG4sngPmGPICTS5EnxqhKbCmz5Ox5hsszI2T6U5qdrJizBc+0ilYSEjTSzU0yZcmvppztXe/5Al5fUwdg==",
+      "dev": true
+    },
     "node_modules/y18n": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.2.tgz",
@@ -1926,6 +3102,18 @@
         "string-width": "^1.0.1",
         "window-size": "^0.1.4",
         "y18n": "^3.2.0"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -16,5 +16,12 @@
     "immutable": "^5.0.0-rc.2",
     "rxjs": "^7.8.1",
     "uuid": "^11.0.2"
+  },
+  "devDependencies": {
+    "@eslint/eslintrc": "^3.1.0",
+    "@eslint/js": "^9.14.0",
+    "eslint": "^9.14.0",
+    "globals": "^15.12.0",
+    "jsdoc": "^4.0.4"
   }
 }


### PR DESCRIPTION
Implement a new subclass of ServiceClient which provides Rx APIs. This is a subclass to avoid a mandatory dep on rxjs for service-client.

Implement a generic interface to the `notify/v2` API on a service.

Implement the specific ConfigDB notify endpoints.